### PR TITLE
feat: to support Fahrenheit temp unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Features:
 
 <br>
 
-Two main APIs being used to retrieve weather forecast daa:
+Two main APIs being used to retrieve weather forecast data:
 1. `https://api.openweathermap.org/current`
 2. `https://api.openweathermap.org/forecast5`
 
@@ -33,12 +33,11 @@ Preparation:
 
 Important note / Improvements:
 1. No proper error handling done, for any API call, Geolocation API and etc. So, assumption is to always allow location when browser prompted.
-2. No data valiation for pesisted data.
-3. Temperature only dispaly in (°C) Celcius format now.
-4. City tab changing, then retrieve 5 days weather forecast data potentially have race condition.
-5. ~~CORS issue with Firefox and Safari, do use **Chrome** browser to test this.~~ Updated to use fetch API. CORS issue appearing when using axios, it is due to preflight issue with OPTIONS method being run. So, By using fetch API, it means IE browser is not supported. [Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#browser_compatibility).
-6. Geolocation API is failing in Safari due to insecure connection (http://localhost). Other cities feature are working fine.
-7. This project is not tested with IE browser.
+2. No data validation for persisted data.
+3. City tab changing, then retrieve 5 days weather forecast data, will potentially have race condition.
+4. ~~CORS issue with Firefox and Safari, do use **Chrome** browser to test this.~~ Updated to use fetch API. CORS issue appearing when using axios, it is due to preflight issue with OPTIONS method being run. So, By using fetch API, it means IE browser is not supported. [Browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API#browser_compatibility).
+5. Geolocation API is failing in Safari due to insecure connection (http://localhost). Other cities feature are working fine.
+6. This project is not tested with IE browser.
 
 <hr>
 

--- a/components/DayWeatherRow.vue
+++ b/components/DayWeatherRow.vue
@@ -20,13 +20,18 @@
       tabindex="0"
       aria-label="max and min temperature"
     >
-      <div class="day-weather-temp-max">{{ maxTempCelcius }}&#8451;</div>
-      <div class="day-weather-temp-min">{{ minTempCelcius }}&#8451;</div>
+      <div class="day-weather-temp-max">
+        {{ maxTempCelcius }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+      </div>
+      <div class="day-weather-temp-min">
+        {{ minTempCelcius }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+      </div>
     </div>
   </div>
 </template>
 
 <script>
+import processTemperature from '~/utils/processTemperature'
 export default {
   props: {
     day: {
@@ -45,6 +50,10 @@ export default {
       type: Number,
       default: null,
     },
+    isFahrenheit: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     dayStr() {
@@ -58,15 +67,11 @@ export default {
     },
     maxTempCelcius() {
       if (this.maxTemp == null) return this.$constants.NA_STR
-      return this.maxTemp
-        ? (this.maxTemp + this.$constants.KELVIN_CELCIUS).toFixed(1)
-        : this.maxTemp
+      return processTemperature(this.maxTemp, this.isFahrenheit)
     },
     minTempCelcius() {
       if (this.minTemp == null) return this.$constants.NA_STR
-      return this.minTemp
-        ? (this.minTemp + this.$constants.KELVIN_CELCIUS).toFixed(1)
-        : this.minTemp
+      return processTemperature(this.minTemp, this.isFahrenheit)
     },
   },
 }

--- a/components/DayWeatherRow.vue
+++ b/components/DayWeatherRow.vue
@@ -21,10 +21,10 @@
       aria-label="max and min temperature"
     >
       <div class="day-weather-temp-max">
-        {{ maxTempCelcius }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+        {{ maxProcessedTemp }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
       </div>
       <div class="day-weather-temp-min">
-        {{ minTempCelcius }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+        {{ minProcessedTemp }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
       </div>
     </div>
   </div>
@@ -65,11 +65,11 @@ export default {
         this.icon && 'http://openweathermap.org/img/wn/' + this.icon + '@2x.png'
       )
     },
-    maxTempCelcius() {
+    maxProcessedTemp() {
       if (this.maxTemp == null) return this.$constants.NA_STR
       return processTemperature(this.maxTemp, this.isFahrenheit)
     },
-    minTempCelcius() {
+    minProcessedTemp() {
       if (this.minTemp == null) return this.$constants.NA_STR
       return processTemperature(this.minTemp, this.isFahrenheit)
     },

--- a/components/DayWeatherSteps.vue
+++ b/components/DayWeatherSteps.vue
@@ -6,6 +6,7 @@
       :icon="weather.icon"
       :temperature="weather.temp"
       :time="weather.time"
+      :is-fahrenheit="isFahrenheit"
     />
   </div>
 </template>
@@ -18,6 +19,10 @@ export default {
       default: () => {
         return []
       },
+    },
+    isFahrenheit: {
+      type: Boolean,
+      default: false,
     },
   },
 }

--- a/components/OtherCities.vue
+++ b/components/OtherCities.vue
@@ -14,7 +14,10 @@
       :on-tab-click="onCityTabClick"
       :on-add-tab-click="addCityClick"
     />
-    <WeatherCardCity5Days :city-weather="fiveDaysWeather" />
+    <WeatherCardCity5Days
+      :city-weather="fiveDaysWeather"
+      :is-fahrenheit="isFahrenheit"
+    />
   </div>
 </template>
 
@@ -82,6 +85,9 @@ export default {
     }
   },
   computed: {
+    isFahrenheit() {
+      return this.$store.state.isFahrenheit
+    },
     fiveDaysWeather() {
       const index = this.$store.state.selectedTabIndex
       const cityId = this.$store.state.selectedCities[index]

--- a/components/TemperatureUnit.vue
+++ b/components/TemperatureUnit.vue
@@ -1,0 +1,66 @@
+<template>
+  <div class="temperature-unit">
+    <button
+      aria-label="Fahrenheit"
+      alt="Fahrenheit"
+      :class="{ active: !isFahrenheit }"
+      @click="(e) => isFahrenheit && toggle(e)"
+    >
+      &#8451;
+    </button>
+    <button
+      aria-label="Celcius"
+      alt="Celcius"
+      :class="{ active: isFahrenheit }"
+      @click="(e) => !isFahrenheit && toggle(e)"
+    >
+      &#8457;
+    </button>
+  </div>
+</template>
+
+<script>
+export default {
+  computed: {
+    isFahrenheit() {
+      return this.$store.state.isFahrenheit
+    },
+  },
+  methods: {
+    toggle() {
+      this.$store.commit('toggleTemperatureUnit')
+    },
+  },
+}
+</script>
+
+<style>
+.temperature-unit {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  width: 100%;
+}
+
+.temperature-unit button {
+  appearance: none;
+  background-color: transparent;
+  border: 0;
+  font-family: inherit;
+  font-size: 1rem;
+  border-radius: 8px;
+  width: 40px;
+  height: 40px;
+  cursor: default;
+  transition: all 0.3s ease;
+}
+
+.temperature-unit button:not(.active):hover {
+  background-color: rgba(0, 0, 0, 5%);
+  cursor: pointer;
+}
+
+.temperature-unit button.active {
+  font-weight: bold;
+}
+</style>

--- a/components/WeatherCard.vue
+++ b/components/WeatherCard.vue
@@ -10,7 +10,7 @@
           {{ weather }}
         </div>
         <div class="weather-temp">
-          {{ temperatureCelcius }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+          {{ processedTemp }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
         </div>
       </div>
     </div>
@@ -18,8 +18,7 @@
       <div class="weather-details-sm">
         <label><strong>Feels Like</strong></label>
         <div>
-          {{ temperatureFeelsLikeCelcius
-          }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+          {{ processedTempFeelsLike }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
         </div>
       </div>
       <div class="weather-details-sm">
@@ -72,11 +71,11 @@ export default {
     },
   },
   computed: {
-    temperatureCelcius() {
+    processedTemp() {
       if (this.temperature == null) return this.$constants.NA_STR
       return processTemperature(this.temperature, this.isFahrenheit)
     },
-    temperatureFeelsLikeCelcius() {
+    processedTempFeelsLike() {
       if (this.temperatureFeelsLike == null) return this.$constants.NA_STR
       return processTemperature(this.temperatureFeelsLike, this.isFahrenheit)
     },

--- a/components/WeatherCard.vue
+++ b/components/WeatherCard.vue
@@ -9,13 +9,18 @@
         <div class="weather-desc">
           {{ weather }}
         </div>
-        <div class="weather-temp">{{ temperatureCelcius }}&#8451;</div>
+        <div class="weather-temp">
+          {{ temperatureCelcius }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+        </div>
       </div>
     </div>
     <div class="weather-details-2">
       <div class="weather-details-sm">
         <label><strong>Feels Like</strong></label>
-        <div>{{ temperatureFeelsLikeCelcius }}&#8451;</div>
+        <div>
+          {{ temperatureFeelsLikeCelcius
+          }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+        </div>
       </div>
       <div class="weather-details-sm">
         <label><strong>Humidity</strong></label>
@@ -30,6 +35,7 @@
 </template>
 
 <script>
+import processTemperature from '~/utils/processTemperature'
 export default {
   props: {
     icon: {
@@ -60,17 +66,19 @@ export default {
       type: Number,
       default: null,
     },
+    isFahrenheit: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     temperatureCelcius() {
       if (this.temperature == null) return this.$constants.NA_STR
-      return (this.temperature + this.$constants.KELVIN_CELCIUS).toFixed(1)
+      return processTemperature(this.temperature, this.isFahrenheit)
     },
     temperatureFeelsLikeCelcius() {
       if (this.temperatureFeelsLike == null) return this.$constants.NA_STR
-      return (
-        this.temperatureFeelsLike + this.$constants.KELVIN_CELCIUS
-      ).toFixed(1)
+      return processTemperature(this.temperatureFeelsLike, this.isFahrenheit)
     },
   },
 }

--- a/components/WeatherCardCity5Days.vue
+++ b/components/WeatherCardCity5Days.vue
@@ -10,9 +10,13 @@
         :icon="weather.icon"
         :max-temp="weather.maxTemp"
         :min-temp="weather.minTemp"
+        :is-fahrenheit="isFahrenheit"
       />
       <div class="overflow-scroll">
-        <DayWeatherSteps :weathers="weather.threeHourly" />
+        <DayWeatherSteps
+          :weathers="weather.threeHourly"
+          :is-fahrenheit="isFahrenheit"
+        />
       </div>
     </div>
   </div>
@@ -26,6 +30,10 @@ export default {
       default() {
         return []
       },
+    },
+    isFahrenheit: {
+      type: Boolean,
+      default: false,
     },
   },
   computed: {

--- a/components/WeatherCardSm.vue
+++ b/components/WeatherCardSm.vue
@@ -2,7 +2,7 @@
   <div class="weather-card-sm" tabindex="0">
     <img class="weather-card-sm-icon" alt="weather icon" :src="getIcon" />
     <div class="weather-card-sm-temp">
-      {{ temperatureCelcius }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+      {{ processedTemp }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
     </div>
     <div class="weather-card-sm-time">{{ timeAMPM }}</div>
   </div>
@@ -37,7 +37,7 @@ export default {
         this.icon && 'http://openweathermap.org/img/wn/' + this.icon + '@2x.png'
       )
     },
-    temperatureCelcius() {
+    processedTemp() {
       if (this.temperature == null) return this.$constants.NA_STR
       return processTemperature(this.temperature, this.isFahrenheit)
     },

--- a/components/WeatherCardSm.vue
+++ b/components/WeatherCardSm.vue
@@ -1,13 +1,16 @@
 <template>
   <div class="weather-card-sm" tabindex="0">
     <img class="weather-card-sm-icon" alt="weather icon" :src="getIcon" />
-    <div class="weather-card-sm-temp">{{ temperatureCelcius }}&#8451;</div>
+    <div class="weather-card-sm-temp">
+      {{ temperatureCelcius }}{{ isFahrenheit ? '&#8457;' : '&#8451;' }}
+    </div>
     <div class="weather-card-sm-time">{{ timeAMPM }}</div>
   </div>
 </template>
 
 <script>
 import { parseISO } from 'date-fns'
+import processTemperature from '~/utils/processTemperature'
 export default {
   props: {
     icon: {
@@ -22,6 +25,10 @@ export default {
       type: String,
       default: null,
     },
+    isFahrenheit: {
+      type: Boolean,
+      default: false,
+    },
   },
   computed: {
     getIcon() {
@@ -31,7 +38,8 @@ export default {
       )
     },
     temperatureCelcius() {
-      return (this.temperature + this.$constants.KELVIN_CELCIUS).toFixed(1)
+      if (this.temperature == null) return this.$constants.NA_STR
+      return processTemperature(this.temperature, this.isFahrenheit)
     },
     timeAMPM() {
       const hour = parseISO(this.time).getHours()

--- a/components/WeatherCardWrapper.vue
+++ b/components/WeatherCardWrapper.vue
@@ -15,6 +15,7 @@
       :temperature-feels-like="current.main.feels_like"
       :humidity="current.main.humidity"
       :pressure="current.main.pressure"
+      :is-fahrenheit="isFahrenheit"
     />
   </div>
 </template>
@@ -60,6 +61,9 @@ function retrieveCurrentLocationWeather() {
 
 export default {
   computed: {
+    isFahrenheit() {
+      return this.$store.state.isFahrenheit
+    },
     current() {
       return this.$store.state.current?.data
     },

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="container">
+    <TemperatureUnit />
     <div class="weather">
       <WeatherCardWrapper />
       <OtherCities />

--- a/store/index.js
+++ b/store/index.js
@@ -6,6 +6,7 @@ const cityById = cities.reduce(
 )
 
 export const state = () => ({
+  isFahrenheit: false,
   current: {
     status: 'idle',
     data: {
@@ -24,6 +25,9 @@ export const state = () => ({
 })
 
 export const mutations = {
+  toggleTemperatureUnit(state) {
+    state.isFahrenheit = !state.isFahrenheit
+  },
   currentFetchStatus(state, status) {
     state.current.status = status
   },

--- a/utils/processTemperature.js
+++ b/utils/processTemperature.js
@@ -1,0 +1,9 @@
+const KELVIN_CELCIUS = -273.15
+
+function processTemperature(kelvin, isFahrenheit, decimals = 1) {
+  if (isFahrenheit)
+    return (((kelvin + KELVIN_CELCIUS) * 9) / 5 + 32).toFixed(decimals)
+  return (kelvin + KELVIN_CELCIUS).toFixed(decimals)
+}
+
+export default processTemperature


### PR DESCRIPTION
### Summary

- Keep `isFahrenheit` state in store
- Passing down `is-fahrenheit` props down from container (where all the logics at) to presentational components.
- Created util directory with `processTemperature()` function to process the temperature accordingly based on given arguments value

### Test

#### Chrome

![celcius farenheit ](https://user-images.githubusercontent.com/6974703/120179509-3f8e0e00-c23d-11eb-9b1d-bc9251c50820.gif)

#### Safari

<img width="1440" alt="Screenshot 2021-05-31 at 6 16 52 pm" src="https://user-images.githubusercontent.com/6974703/120179494-3bfa8700-c23d-11eb-8997-7bf415eebe79.png">

#### Firefox

<img width="1440" alt="Screenshot 2021-05-31 at 6 16 35 pm" src="https://user-images.githubusercontent.com/6974703/120179505-3ef57780-c23d-11eb-96f7-c661fd7b3003.png">
